### PR TITLE
RPATH Fix For webOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,16 +222,17 @@ if(OPTION_PACKAGE_DEPENDENCIES)
         message(FATAL_ERROR "OPTION_PACKAGE_DEPENDENCIES can only work with CMake 3.16+; you are using ${CMAKE_VERSION}")
     endif()
 
-    if (NOT WEBOS)
-        # If we are packaging dependencies, we do two things:
-        # 1) set the RPATH to include $ORIGIN/lib; $ORIGIN (that literal string)
-        #    is a Linux indicator for "path where application is". In CMake, we
-        #    have to do this before add_executable() is executed.
-        # 2) copy the libraries that we compile against to the "lib" folder.
-        #    This is done in InstallAndPackage.cmake.
-        set(CMAKE_INSTALL_RPATH "\$ORIGIN/lib")
-        set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-    endif()
+    # If we are packaging dependencies, we do two things:
+    # 1) set the RPATH to include $ORIGIN/lib; $ORIGIN (that literal string)
+    #    is a Linux indicator for "path where application is". In CMake, we
+    #    have to do this before add_executable() is executed.
+    # 2) copy the libraries that we compile against to the "lib" folder.
+    #    This is done in InstallAndPackage.cmake.
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN/lib")
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+    if (WEBOS)
+        set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+    endif ()
 endif()
 
 include(CTest)

--- a/os/webos/package.sh
+++ b/os/webos/package.sh
@@ -12,19 +12,12 @@ cp -r ../../build/openttd dist/openttd
 cp -r public/. dist/
 
 mkdir dist/lib
-cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libicudata.so.70.1 dist/lib
-ln -rs dist/lib/libicudata.so.70.1 dist/lib/libicudata.so.70
-cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libicui18n.so.70.1 dist/lib
-ln -rs dist/lib/libicui18n.so.70.1 dist/lib/libicui18n.so.70
-cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libicuuc.so.70.1 dist/lib
-ln -rs dist/lib/libicuuc.so.70.1 dist/lib/libicuuc.so.70
-cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libstdc++.so.6.0.30 dist/lib
-ln -rs dist/lib/libstdc++.so.6.0.30 dist/lib/libstdc++.so.6
-cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libfluidsynth.so.3.3.3 dist/lib
-ln -rs dist/lib/libfluidsynth.so.3.3.3 dist/lib/libfluidsynth.so.3
-cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libreadline.so.8.1 dist/lib
-ln -rs dist/lib/libreadline.so.8.1 dist/lib/libreadline.so.8
-cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/lib/libatomic.so.1.2.0 dist/lib
-ln -rs dist/lib/libatomic.so.1.2.0 dist/lib/libatomic.so.1
+cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libicudata.so.70.1 dist/libicudata.so.70
+cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libicui18n.so.70.1 dist/libicui18n.so.70
+cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libicuuc.so.70.1 dist/libicuuc.so.70
+cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libstdc++.so.6.0.30 dist/libstdc++.so.6
+cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libfluidsynth.so.3.3.3 dist/libfluidsynth.so.3
+cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/usr/lib/libreadline.so.8.1 dist/libreadline.so.8
+cp $TOOLCHAIN_DIRECTORY/arm-webos-linux-gnueabi/sysroot/lib/libatomic.so.1.2.0 dist/libatomic.so.1
 
 ares-package dist/


### PR DESCRIPTION
This PR sets RPATH to `$ORIGIN` for webOS, so it loads library in the same directory `openttd` program placed.

Also the build script now copies `libstdc++.so.6` to the directory where `openttd` located, so it has higher precedence over the system one. While `libcurl.so.4` is still in `lib` directory, which becomes fallback only when `libcurl.so.5` exists while `libcurl.so.4` not.


Compatibility tool looks happy now!

![image](https://github.com/user-attachments/assets/6d06df51-0aa5-4ed8-9e61-c829a0b8e958)
